### PR TITLE
Monkey-test

### DIFF
--- a/app/monkey-test-runner.sh
+++ b/app/monkey-test-runner.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# First parameter is amount of events, second is sleeping time between events in milliseconds
+
+event_count=1000
+throttle=0
+
+if [[ -n "$1" && "$1" -ge 0 ]]
+then
+event_count=$1
+fi
+
+if [[ -n "$2" && "$2" -ge 0 ]]
+then
+throttle=$2
+fi
+
+adb shell monkey -v -v -v --throttle $throttle --pct-syskeys 0 -p ru.spb.speech $event_count

--- a/app/monkey-test-stop.sh
+++ b/app/monkey-test-stop.sh
@@ -1,0 +1,1 @@
+adb shell ps | awk '/com\.android\.commands\.monkey/ { system("adb shell kill " $2) }'


### PR DESCRIPTION
Для запуска скрипта необходимо, чтобы Android Debug Bridge (adb) был доступен из консоли.
Скрипт имеет два параметра, первый отвечает за количество действий, которые будут выполнены в ходе тестирования, второй отвечает за паузы между действиями (задается в миллисекундах).
В ходе тестирования в консоль выдается отчет о том, какие действия совершает тест:
![image](https://user-images.githubusercontent.com/32985488/60759531-4d29c180-a02f-11e9-91a3-2550035327a7.png)
В случае возникновения ошибки, в консоль будет выведен соответствующий stack trace вида:
![image](https://user-images.githubusercontent.com/32985488/60759596-6f700f00-a030-11e9-9ec6-41ac85887993.png)
